### PR TITLE
Repair script

### DIFF
--- a/data/bechdel.cabal
+++ b/data/bechdel.cabal
@@ -35,3 +35,9 @@ executable parsechakoteya
                        parsec >=3.1,
                        split >= 0.2
   default-language:    Haskell2010
+
+executable repair
+  main-is:             startrek/repair.hs
+  build-depends:       base >=4.7 && <4.8,
+                       bechdel
+  default-language:    Haskell2010

--- a/data/bechdel.cabal
+++ b/data/bechdel.cabal
@@ -21,6 +21,7 @@ library
                        Data.Bechdel.Util
 
   build-depends:       base >=4.7 && <4.8,
+                       MissingH >=1.3,
                        parsec >=3.1
 
   default-language:    Haskell2010
@@ -39,5 +40,6 @@ executable parsechakoteya
 executable repair
   main-is:             startrek/repair.hs
   build-depends:       base >=4.7 && <4.8,
-                       bechdel
+                       bechdel,
+                       containers >=0.5
   default-language:    Haskell2010

--- a/data/bechdel/Data/Bechdel.hs
+++ b/data/bechdel/Data/Bechdel.hs
@@ -1,6 +1,7 @@
 module Data.Bechdel where
 import Data.List
 import Data.Maybe
+import Data.String.Utils
 import Text.ParserCombinators.Parsec
 
 -- Used to print data into a standard format.
@@ -40,6 +41,7 @@ instance Format Role where
         genderStr = case gender role of
             Just Male ->   "m"
             Just Female -> "f"
+            Just Neither -> "n"
             Nothing ->     "u"
         noteStr = maybe "" (\x -> concat ["[", x, "]"]) $ note role
 
@@ -62,7 +64,7 @@ parseRole = do
     name <- manyTill anyChar (lookAhead $ char '(')
     genderLetter <- between (char '(') (char ')') $ oneOf "mfnu"
     note <- optionMaybe $ between (char '[') (char ']') (many $ noneOf "[]")
-    return $ Role name (gender genderLetter) note
+    return $ Role (strip name) (gender genderLetter) note
   where
     gender :: Char -> Maybe Gender
     gender genderLetter = case genderLetter of

--- a/data/bechdel/Data/Bechdel.hs
+++ b/data/bechdel/Data/Bechdel.hs
@@ -87,7 +87,8 @@ parseLine = do
 -- Parse a ScriptLine out of a stage direction.
 parseStageDirection :: GenParser Char () ScriptLine
 parseStageDirection = do
-    text <- between (char '(') (char ')') (many $ noneOf "()")
+    char '('
+    text <- manyTill anyChar (try $ lookAhead (char ')' >> spaces >> eof))
     return $ StageDirection text
 
 parseScene :: GenParser Char () ScriptLine

--- a/data/startrek/repair.hs
+++ b/data/startrek/repair.hs
@@ -2,6 +2,7 @@ import Control.Monad
 import Data.Bechdel
 import Data.Either
 import Data.Functor
+import qualified Data.Map as M
 import System.Environment
 import System.Exit
 import System.IO
@@ -15,6 +16,44 @@ fillName l@(Line r@Role{name="UNKNOWN"} s) = do
     name <- getLine
     return $ Line r{name=name} s
 fillName r = return r
+
+-- Ask the user for a gender if one is missing; use the map to store cached
+-- previous answers.
+fillGender :: M.Map String Gender -> ScriptLine -> IO (M.Map String Gender, ScriptLine)
+fillGender cache l@(Line r@Role{gender=Nothing} s) = do
+    case M.lookup (name r) cache of
+        Just g  -> return (cache, Line r{gender=Just g} s)
+        Nothing -> do
+            hPutStrLn stderr $ format l
+            hPutStr stderr "What is the role's gender? "
+            hFlush stderr
+            g <- translate . head <$> getLine
+            let newCache = M.insert (name r) g cache
+            return (newCache, Line r{gender=Just g} s)
+  where
+    translate :: Char -> Gender
+    translate 'm' = Male
+    translate 'f' = Female
+    translate 'n' = Neither
+    translate c = error $ "Illegal character for gender: " ++ show c
+fillGender cache l@(Line r@Role{gender=Just g} s) = return (M.insert (name r) g cache, l)
+fillGender cache l = return (cache, l)
+
+-- Apply fillGender to a list of ScriptLines, threading the evolving cache
+-- through the invocations.
+--
+-- TODO: replace this one-off mechanism with a use of StateT monad.
+fillGenders :: [ScriptLine] -> IO [ScriptLine]
+fillGenders = go (M.fromList [])
+  where
+    go :: M.Map String Gender -> [ScriptLine] -> IO [ScriptLine]
+    go _ [] = return []
+    go cache (x:xs) = do
+        result <- fillGender cache x
+        let newCache = fst result
+        let value = snd result
+        rest <- go newCache xs
+        return $ value : rest
 
 main :: IO ()
 main = do
@@ -40,6 +79,9 @@ main = do
     -- Find script lines with characters with unknown names.
     namedScript <- mapM fillName script
 
-    mapM_ (putStrLn . format) namedScript
+    -- Find script lines with characters with unknown gender.
+    genderedNamedScript <- fillGenders namedScript
+
+    mapM_ (putStrLn . format) genderedNamedScript
 
     exitSuccess

--- a/data/startrek/repair.hs
+++ b/data/startrek/repair.hs
@@ -1,0 +1,45 @@
+import Control.Monad
+import Data.Bechdel
+import Data.Either
+import Data.Functor
+import System.Environment
+import System.Exit
+import System.IO
+
+-- Ask the user for a name if one is missing.
+fillName :: ScriptLine -> IO ScriptLine
+fillName l@(Line r@Role{name="UNKNOWN"} s) = do
+    hPutStrLn stderr $ format l
+    hPutStr stderr "What is the role's name? "
+    hFlush stderr
+    name <- getLine
+    return $ Line r{name=name} s
+fillName r = return r
+
+main :: IO ()
+main = do
+    -- Read a script in from the file named in the first argument.
+    args <- getArgs
+    when (null args) $ do
+        hPutStrLn stderr "usage: repair <scriptfile>"
+        exitFailure
+    text <- lines <$> readFile (head args)
+
+    -- Parse into ScriptLines
+    let scriptParse = map parseScriptLine text
+
+    -- Check for well formedness of the result.
+    let bad = filter (isLeft . fst) $ zip scriptParse text
+    unless (null bad) $ do
+        hPutStrLn stderr "Error - badly formatted script line:"
+        hPutStrLn stderr (snd . head $ bad)
+        exitFailure
+
+    let script = rights scriptParse
+
+    -- Find script lines with characters with unknown names.
+    namedScript <- mapM fillName script
+
+    mapM_ (putStrLn . format) namedScript
+
+    exitSuccess


### PR DESCRIPTION
Interactive script to "repair" a script with incomplete data. Proceeds in two phases:
1. For each role named "UNKNOWN", asks the user for the real name of the role. This is mainly for log entries, since these may be made by many characters on a given show, and it is impossible to tell who is making the entry programmatically.
2. For each role missing a gender (which, initially, is all of them), asks the user for a gender. The answer for a given named role is cached for the repair of a given script.

The resulting, "repaired" script lines are then written to stdout.
