### PR TITLE
Implement "join" and "exit" commands during interactive editing

### DIFF
--- a/app/startrek/parsechakoteya.hs
+++ b/app/startrek/parsechakoteya.hs
@@ -62,7 +62,7 @@ parseRawLine s = parse parser s s
 parseHTML = readString [withParseHTML yes, withWarnings no]
 
 -- Extract all appropriate text nodes comprising script.
-extractScriptText html = runX $ html >>> css "table p font" //> getText
+extractScriptText html = runX $ html >>> css "table font" //> getText
 
 -- Convenience function.
 readHTMLScript = extractScriptText . parseHTML


### PR DESCRIPTION
- `join` - appends a space and then the current text to the previous line. Useful if for some reason the script contains a fragment of the previous character's lines in its own element in the HTML for some reason
- `exit` - stops processing immediately; does not write to the output file, and exits with nonzero error code